### PR TITLE
Added --no-sandbox for newer versions of Cursor

### DIFF
--- a/cursor.sh
+++ b/cursor.sh
@@ -76,7 +76,7 @@ function install_cursor() {
     cp squashfs-root/cursor.desktop "$apps_dir/"
 
     # Update desktop file to point to the correct AppImage location
-    sed -i "s|Exec=.*|Exec=$install_dir/cursor.appimage|g" "$apps_dir/cursor.desktop"
+    sed -i "s|Exec=.*|Exec=$install_dir/cursor.appimage --no-sandbox|g" "$apps_dir/cursor.desktop"
 
     # Clean up
     cd "$current_dir"


### PR DESCRIPTION
Since version 0.44 or 0.45, Cursor cannot run without the --no-sandbox flag
Source : https://forum.cursor.com/t/cannot-launch-cursor-without-no-sandbox/35261