### PR TITLE
Fix: Correct Icon= name in extracted .desktop file

### DIFF
--- a/cursor.sh
+++ b/cursor.sh
@@ -181,6 +181,9 @@ function install_cursor() {
     # Update desktop file to point to the correct AppImage location
     sed -i "s|Exec=.*|Exec=$install_dir/cursor.appimage --no-sandbox|g" "$apps_dir/cursor.desktop"
 
+    # Fix potential icon name mismatch in the extracted desktop file
+    sed -i 's/^Icon=co.anysphere.cursor/Icon=cursor/' "$apps_dir/cursor.desktop"
+
     # Clean up
     cd "$current_dir"
     rm -rf "$temp_extract_dir"


### PR DESCRIPTION
This PR fixes an issue where the installed Cursor application shows a generic icon instead of the correct one on some Linux desktops.

**Problem:**
The `cursor.desktop` file included within the official Cursor AppImage specifies `Icon=co.anysphere.cursor`. However, the icon files extracted from the same AppImage correspond to the base name `cursor` (e.g., `cursor.png` files are placed in the hicolor theme). This mismatch causes the desktop environment to fail to find the icon.

**Solution:**
This change adds a `sed` command to the `install_cursor` function. After extracting and copying the `cursor.desktop` file, this command automatically corrects the line `Icon=co.anysphere.cursor` to `Icon=cursor`, matching the actual extracted icon names.

This ensures the correct icon is displayed in application menus/docks after installation via this script.