### PR TITLE
feat: cursor shim for ~/.local/bin/cursor

### DIFF
--- a/cursor.sh
+++ b/cursor.sh
@@ -21,14 +21,6 @@ fi
 
 CLI_NAME="cursor-installer"
 CLI_BIN="$HOME/.local/bin/$CLI_NAME"
-REPO_OWNER=${REPO_OWNER:-watzon}
-REPO_BRANCH=${REPO_BRANCH:-main}
-REPO_NAME=${REPO_NAME:-cursor-linux-installer}
-BASE_RAW_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${REPO_BRANCH}"
-SHARED_SHIM="$LIB_DIR/shim.sh"
-SHIM_URL="$BASE_RAW_URL/shim.sh"
-SHIM_HELPER="$LIB_DIR/ensure-shim.sh"
-SHIM_HELPER_URL="$BASE_RAW_URL/scripts/ensure-shim.sh"
 
 # Installation mode: 'appimage' (default) or 'extracted'
 # Can be set via CURSOR_INSTALL_MODE environment variable or --extract flag
@@ -48,42 +40,11 @@ function get_extracted_root() {
         fi
     done
     return 1
-} 
+}
 
 function get_extraction_dir() {
     # Prefer ~/.local/share/cursor for extracted installations
     echo "$HOME/.local/share/cursor"
-}
-
-function ensure_shim() {
-    if [ -x "$SHIM_HELPER" ]; then
-        if ! "$SHIM_HELPER"; then
-            log_warn "Shim update failed; continuing."
-        fi
-        return 0
-    fi
-    if [ -f "$SHIM_HELPER" ]; then
-        if ! sh "$SHIM_HELPER"; then
-            log_warn "Shim update failed; continuing."
-        fi
-        return 0
-    fi
-    log_info "Shim helper not found; skipping shim update."
-    return 0
-}
-
-function refresh_shim_assets() {
-    log_step "Refreshing cursor shim assets..."
-    mkdir -p "$LIB_DIR"
-    if ! curl -fsSL "$SHIM_URL" -o "$SHARED_SHIM"; then
-        log_warn "Failed to download shim.sh; continuing."
-        return 0
-    fi
-    if ! curl -fsSL "$SHIM_HELPER_URL" -o "$SHIM_HELPER"; then
-        log_warn "Failed to download ensure-shim.sh; continuing."
-        return 0
-    fi
-    chmod +x "$SHIM_HELPER" "$SHARED_SHIM" || true
 }
 
 function check_fuse() {
@@ -328,7 +289,7 @@ EOF
 }
 
 function install_cursor_extracted() {
-    ensure_shim
+    run_ensure_shim
     local install_dir="$1"
     local release_track=${2:-stable}
     local temp_file
@@ -478,7 +439,7 @@ function install_cursor_extracted() {
 }
 
 function install_cursor() {
-    ensure_shim
+    run_ensure_shim
     local install_dir="$1"
     local release_track=${2:-stable} # Default to stable if not specified
     

--- a/install.sh
+++ b/install.sh
@@ -32,23 +32,15 @@ done
 # Determine whether to use local cursor.sh or download from GitHub
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 LOCAL_CURSOR_SH="$SCRIPT_DIR/cursor.sh"
-
-# Repo URL parameters (override via env for release workflows)
+LIB_DIR="$HOME/.local/share/cursor-installer"
+LIB_PATH="$SCRIPT_DIR/lib.sh"
+SHARED_LIB="$LIB_DIR/lib.sh"
 REPO_OWNER=${REPO_OWNER:-watzon}
 REPO_BRANCH=${REPO_BRANCH:-main}
 REPO_NAME=${REPO_NAME:-cursor-linux-installer}
 BASE_RAW_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${REPO_BRANCH}"
-CURSOR_SCRIPT_URL="$BASE_RAW_URL/cursor.sh"
-LIB_DIR="$HOME/.local/share/cursor-installer"
-LIB_PATH="$SCRIPT_DIR/lib.sh"
-SHARED_LIB="$LIB_DIR/lib.sh"
-LIB_URL="$BASE_RAW_URL/lib.sh"
-SHIM_PATH="$SCRIPT_DIR/shim.sh"
-SHARED_SHIM="$LIB_DIR/shim.sh"
-SHIM_URL="$BASE_RAW_URL/shim.sh"
-SHIM_HELPER_LOCAL="$SCRIPT_DIR/scripts/ensure-shim.sh"
-SHIM_HELPER="$LIB_DIR/ensure-shim.sh"
-SHIM_HELPER_URL="$BASE_RAW_URL/scripts/ensure-shim.sh"
+LIB_URL="${BASE_RAW_URL}/lib.sh"
+CURSOR_SCRIPT_URL="${BASE_RAW_URL}/cursor.sh"
 
 # Source shared helpers (local repo, installed lib, or download)
 if [ -f "$LIB_PATH" ]; then
@@ -103,37 +95,7 @@ chmod +x "$CLI_PATH"
 log_ok "Cursor installer script has been placed in $CLI_PATH"
 
 log_step "Ensuring cursor shim..."
-SHIM_READY=true
-if [ -f "$SHIM_PATH" ]; then
-    cp "$SHIM_PATH" "$SHARED_SHIM"
-elif [ -f "$SHARED_SHIM" ]; then
-    :
-else
-    log_info "Downloading shim.sh from GitHub..."
-    if ! curl -fsSL "$SHIM_URL" -o "$SHARED_SHIM"; then
-        log_warn "Failed to download shim.sh; shim update skipped."
-        SHIM_READY=false
-    fi
-fi
-
-if [ "$SHIM_READY" = true ]; then
-    if [ -f "$SHIM_HELPER_LOCAL" ]; then
-        cp "$SHIM_HELPER_LOCAL" "$SHIM_HELPER"
-    else
-        log_info "Downloading ensure-shim.sh from GitHub..."
-        if ! curl -fsSL "$SHIM_HELPER_URL" -o "$SHIM_HELPER"; then
-            log_warn "Failed to download ensure-shim.sh; shim update skipped."
-            SHIM_READY=false
-        fi
-    fi
-fi
-
-if [ "$SHIM_READY" = true ]; then
-    chmod +x "$SHIM_HELPER" "$SHARED_SHIM" || true
-    if ! "$SHIM_HELPER"; then
-        log_warn "Shim update failed; continuing installation."
-    fi
-fi
+LOCAL_SHIM_PATH="$SCRIPT_DIR/shim.sh" LOCAL_SHIM_HELPER_PATH="$SCRIPT_DIR/scripts/ensure-shim.sh" sync_shim_assets && run_ensure_shim || log_warn "Shim update skipped or failed; continuing."
 
 # Check if ~/.local/bin is in PATH
 if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then

--- a/scripts/ensure-shim.sh
+++ b/scripts/ensure-shim.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Install or update ~/.local/bin/cursor shim. Skips if existing file is already our shim.
+set -eu
+
+TARGET_SHIM="${TARGET_SHIM:-$HOME/.local/bin/cursor}"
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+LIB_DIR="${HOME}/.local/share/cursor-installer"
+
+SOURCE_SHIM="${SOURCE_SHIM:-}"
+if [ -z "$SOURCE_SHIM" ]; then
+  if [ -f "$LIB_DIR/shim.sh" ]; then
+    SOURCE_SHIM="$LIB_DIR/shim.sh"
+  elif [ -f "$SCRIPT_DIR/shim.sh" ]; then
+    SOURCE_SHIM="$SCRIPT_DIR/shim.sh"
+  elif [ -f "$SCRIPT_DIR/../shim.sh" ]; then
+    SOURCE_SHIM="$SCRIPT_DIR/../shim.sh"
+  fi
+fi
+
+if [ -z "$SOURCE_SHIM" ] || [ ! -f "$SOURCE_SHIM" ]; then
+  echo "Error: shim.sh source not found." >&2
+  exit 1
+fi
+
+is_shim() {
+  file="$1"
+  [ -f "$file" ] || return 1
+  first_line=$(head -n 1 "$file" 2>/dev/null || true)
+  case "$first_line" in
+    "#!/bin/sh"|\
+    "#!/usr/bin/env sh"|\
+    "#!/bin/bash"|\
+    "#!/usr/bin/env bash")
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  if grep -q "Find cursor executable in PATH" "$file" 2>/dev/null; then
+    return 0
+  fi
+  if grep -q "cursor-installer" "$file" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+is_current_shim() {
+  is_shim "$TARGET_SHIM" || return 1
+  cmp -s "$SOURCE_SHIM" "$TARGET_SHIM"
+}
+
+if is_current_shim; then
+  echo "Cursor shim already installed; skipping."
+  exit 0
+fi
+
+if [ ! -e "$TARGET_SHIM" ]; then
+  mkdir -p "$(dirname "$TARGET_SHIM")"
+  cp "$SOURCE_SHIM" "$TARGET_SHIM"
+  chmod +x "$TARGET_SHIM"
+  echo "Installed cursor shim at $TARGET_SHIM"
+  exit 0
+fi
+
+if ! is_shim "$TARGET_SHIM"; then
+  echo "Skipping shim update; existing cursor is not a shim: $TARGET_SHIM"
+  exit 0
+fi
+
+cp "$SOURCE_SHIM" "$TARGET_SHIM"
+chmod +x "$TARGET_SHIM"
+echo "Updated cursor shim at $TARGET_SHIM"

--- a/shim.sh
+++ b/shim.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+# Find cursor executable in PATH, excluding the current shim
+find_cursor() {
+  old_IFS="$IFS"
+  IFS=:
+  for dir in $PATH; do
+    [ -n "$dir" ] || continue
+    cursor_path="$dir/cursor"
+    if [ "$cursor_path" != "$HOME/.local/bin/cursor" ] && [ -x "$cursor_path" ]; then
+      IFS="$old_IFS"
+      echo "$cursor_path"
+      return 0
+    fi
+  done
+  IFS="$old_IFS"
+  return 1
+}
+
+OTHER_CURSOR=$(find_cursor || true)
+CURSOR_INSTALLER=$(command -v cursor-installer 2>/dev/null || true)
+AGENT_BIN="$HOME/.local/bin/agent"
+
+if [ -n "${OTHER_CURSOR:-}" ]; then
+  exec "$OTHER_CURSOR" "$@"
+fi
+
+first_arg="${1:-}"
+
+if [ "$first_arg" = "agent" ]; then
+  if [ -x "$AGENT_BIN" ]; then
+    exec "$AGENT_BIN" "$@"
+  fi
+  echo "Error: Cursor agent not found at $AGENT_BIN" 1>&2
+  exit 1
+fi
+
+if [ -n "${CURSOR_INSTALLER:-}" ]; then
+  exec "$CURSOR_INSTALLER" "$@"
+fi
+
+echo "Error: No Cursor IDE installation found." 1>&2
+echo "Install/update with: cursor-installer --update [stable|latest]" 1>&2
+echo "Or, install Cursor at https://cursor.com/download" 1>&2
+exit 1


### PR DESCRIPTION
Adds an optional `cursor` shim that delegates to `cursor-installer` when no Cursor binary is in PATH.

- **shim.sh**: Installed as `~/.local/bin/cursor`; finds real `cursor` in PATH, else runs `cursor agent` or `cursor-installer` with args.
- **scripts/ensure-shim.sh**: Idempotent install/update; skips if existing file is already our shim; never overwrites a non-shim binary.
- **install.sh**: Syncs shim + helper to `~/.local/share/cursor-installer`, runs ensure-shim after placing CLI.
- **cursor.sh**: Refreshes shim assets from GitHub on `--update`; runs ensure-shim before install/update.

Guards: only replace `~/.local/bin/cursor` when it is already a shim (shebang + marker) or missing.